### PR TITLE
[auto improve] Inject UserDefaults into AppShowcaseService

### DIFF
--- a/Sources/AppShowcaseService.swift
+++ b/Sources/AppShowcaseService.swift
@@ -7,12 +7,18 @@ public class AppShowcaseService: ObservableObject {
 
     private let remoteURL: URL?
     private let currentAppStoreID: String?
+    private let userDefaults: UserDefaults
     private let cacheKey = "cachedMyAppsData"
     private let lastFetchKey = "lastAppsFetchDate"
 
-    public init(remoteURL: URL? = nil, currentAppStoreID: String? = nil) {
+    public init(
+        remoteURL: URL? = nil,
+        currentAppStoreID: String? = nil,
+        userDefaults: UserDefaults = .standard
+    ) {
         self.remoteURL = remoteURL
         self.currentAppStoreID = currentAppStoreID
+        self.userDefaults = userDefaults
         loadApps()
     }
 
@@ -24,7 +30,7 @@ public class AppShowcaseService: ObservableObject {
     public func fetchRemoteAppsIfNeeded() {
         guard let remoteURL = remoteURL else { return }
 
-        let lastFetch = UserDefaults.standard.object(forKey: lastFetchKey) as? Date
+        let lastFetch = userDefaults.object(forKey: lastFetchKey) as? Date
 
         #if DEBUG
         let shouldFetch = true
@@ -59,7 +65,7 @@ public class AppShowcaseService: ObservableObject {
     }
 
     private func loadCachedApps() {
-        guard let data = UserDefaults.standard.data(forKey: cacheKey) else { return }
+        guard let data = userDefaults.data(forKey: cacheKey) else { return }
 
         do {
             let appsData = try JSONDecoder().decode(MyAppsData.self, from: data)
@@ -78,8 +84,8 @@ public class AppShowcaseService: ObservableObject {
             let (data, _) = try await URLSession.shared.data(from: url)
             let appsData = try JSONDecoder().decode(MyAppsData.self, from: data)
 
-            UserDefaults.standard.set(data, forKey: cacheKey)
-            UserDefaults.standard.set(Date(), forKey: lastFetchKey)
+            userDefaults.set(data, forKey: cacheKey)
+            userDefaults.set(Date(), forKey: lastFetchKey)
 
             self.apps = filterCurrentApp(from: appsData.apps)
 

--- a/Tests/AppAboutViewTests/AppShowcaseServiceTests.swift
+++ b/Tests/AppAboutViewTests/AppShowcaseServiceTests.swift
@@ -2,6 +2,22 @@ import Testing
 import Foundation
 @testable import AppAboutView
 
+private func makeIsolatedUserDefaults() -> (userDefaults: UserDefaults, suiteName: String) {
+    let suiteName = "AppShowcaseServiceTests.\(UUID().uuidString)"
+    guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+        fatalError("Failed to create isolated UserDefaults suite")
+    }
+    userDefaults.removePersistentDomain(forName: suiteName)
+    return (userDefaults, suiteName)
+}
+
+private func clearUserDefaults(_ suiteName: String) {
+    guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+        return
+    }
+    userDefaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - AppShowcaseService Tests
 
 @Test @MainActor func testAppShowcaseServiceInitialization() {
@@ -250,26 +266,21 @@ import Foundation
 // MARK: - UserDefaults Integration Tests
 
 @Test @MainActor func testAppShowcaseServiceUserDefaultsInteraction() {
-    // Clear any existing cached data
-    UserDefaults.standard.removeObject(forKey: "cachedMyAppsData")
-    UserDefaults.standard.removeObject(forKey: "lastAppsFetchDate")
+    let isolatedDefaults = makeIsolatedUserDefaults()
+    defer { clearUserDefaults(isolatedDefaults.suiteName) }
     
-    let service = AppShowcaseService()
+    let service = AppShowcaseService(userDefaults: isolatedDefaults.userDefaults)
     service.loadApps()
     
     // Service should work even with clean UserDefaults
     #expect(service.apps.isEmpty || !service.apps.isEmpty)
     
     // Test with corrupted cache data
-    UserDefaults.standard.set("invalid json data", forKey: "cachedMyAppsData")
+    isolatedDefaults.userDefaults.set("invalid json data", forKey: "cachedMyAppsData")
     
-    let serviceWithCorruptedCache = AppShowcaseService()
+    let serviceWithCorruptedCache = AppShowcaseService(userDefaults: isolatedDefaults.userDefaults)
     serviceWithCorruptedCache.loadApps()
     
     // Should handle corrupted cache gracefully
     #expect(serviceWithCorruptedCache.apps.isEmpty || !serviceWithCorruptedCache.apps.isEmpty)
-    
-    // Clean up
-    UserDefaults.standard.removeObject(forKey: "cachedMyAppsData")
-    UserDefaults.standard.removeObject(forKey: "lastAppsFetchDate")
 }


### PR DESCRIPTION
## Why
`AppShowcaseService` was coupled to `UserDefaults.standard` for cache reads and writes. That made the cache path harder to test in isolation and forced tests to mutate shared global defaults.

## What Changed
- Added a `userDefaults: UserDefaults = .standard` dependency to `AppShowcaseService`.
- Routed cached payload and last-fetch persistence through the injected defaults instance.
- Updated the UserDefaults integration test to use a unique suite per test and clean it up afterward.

## Validation
- `swift build`
- `env HOME=/Users/durian/git/autobugfixer/runs/AppAboutView-improve-20260330-111216-959112-r01 CLANG_MODULE_CACHE_PATH=.build/ModuleCache swift test --filter AppAboutViewTests --disable-sandbox`

## Risk Assessment
Low risk. The change is a small dependency injection refactor with the same default behavior for production callers, and the test update only narrows state scope.

## Agent Confidence
High. The patch is small, targeted, and the package build plus filtered test suite passed in the current workspace.