### PR TITLE
[auto improve] Use stable disk cache keys in ImageCache

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 #if canImport(UIKit)
 import UIKit
@@ -33,7 +34,7 @@ public class ImageCache: ObservableObject {
 
     /// Load an image from cache or download it if not cached
     public func loadImage(from urlString: String) async -> PlatformImage? {
-        let cacheKey = cacheKey(for: urlString)
+        let cacheKey = Self.cacheKey(for: urlString)
 
         // Check in-memory cache first
         if let cachedImage = cache.object(forKey: cacheKey as NSString) {
@@ -75,9 +76,9 @@ public class ImageCache: ObservableObject {
 
     // MARK: - Private Methods
 
-    private func cacheKey(for urlString: String) -> String {
-        // Use a simple hash of the URL as the cache key
-        return "\(urlString.hashValue)"
+    static func cacheKey(for urlString: String) -> String {
+        let digest = SHA256.hash(data: Data(urlString.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 
     private func diskCacheURL(for cacheKey: String) -> URL {

--- a/Tests/AppAboutViewTests/ImageCacheTests.swift
+++ b/Tests/AppAboutViewTests/ImageCacheTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import AppAboutView
+
+@Test @MainActor func testImageCacheKeyIsDeterministic() {
+    let url = "https://example.com/icons/app.png?size=512"
+    let expectedKey = "977c83dd78056fd3f76a61e528d4a2fd3d48f3c9614e1ad4033613780ebe01b2"
+
+    #expect(ImageCache.cacheKey(for: url) == expectedKey)
+    #expect(ImageCache.cacheKey(for: url) == ImageCache.cacheKey(for: url))
+}


### PR DESCRIPTION
## Why
`ImageCache` used `String.hashValue` to derive on-disk filenames. In Swift, `hashValue` is intentionally not stable across process launches, so cache files written in one run are not reliably reusable after restart.

## What Changed
- Replaced the disk cache key implementation with a deterministic SHA-256 digest of the source URL.
- Kept the change narrow by reusing the same string key for both memory and disk cache lookups.
- Added a focused regression test that verifies a representative URL maps to a fixed cache key.

## Validation
- Ran `swift build`
- Ran `swift test --filter AppAboutViewTests`

## Risk Assessment
Low risk.
- No public API changes.
- Cache behavior only changes in how filenames are derived.
- SHA-256 hex output is deterministic, path-safe, and collision-resistant for this use case.

## Agent Confidence
High. The patch is small, directly addresses the identified issue, and targeted validation passed.