### PR TITLE
[auto improve] Add deterministic locale coverage for LocalizedDescription

### DIFF
--- a/Sources/LocalizedDescription.swift
+++ b/Sources/LocalizedDescription.swift
@@ -72,8 +72,11 @@ public struct LocalizedDescription: Codable, Hashable {
     }
 
     public var localizedString: String {
+        localizedString(for: .current)
+    }
+
+    public func localizedString(for locale: Locale) -> String {
         // Get the full language identifier including script if present
-        let locale = Locale.current
         let languageCode = locale.language.languageCode?.identifier ?? "en"
         let script = locale.language.script?.identifier
         

--- a/Tests/AppAboutViewTests/LocalizedDescriptionTests.swift
+++ b/Tests/AppAboutViewTests/LocalizedDescriptionTests.swift
@@ -66,18 +66,16 @@ import Foundation
 
 // MARK: - LocalizedDescription Localization Logic Tests
 
-@Test func testLocalizedDescriptionFallbackToEnglish() {
-    let desc = LocalizedDescription(
+@Test func testLocalizedDescriptionGermanLocaleSelection() {
+    let localizedDesc = LocalizedDescription(
         en: "English text",
         de: "German text"
     )
-    
-    // The localized string should never be empty
-    let localizedString = desc.localizedString
-    #expect(!localizedString.isEmpty)
-    
-    // For unsupported locales, should fall back to English
-    #expect(localizedString == "English text" || localizedString == "German text")
+
+    let fallbackDesc = LocalizedDescription(en: "English fallback")
+
+    #expect(localizedDesc.localizedString(for: Locale(identifier: "de_DE")) == "German text")
+    #expect(fallbackDesc.localizedString(for: Locale(identifier: "de_DE")) == "English fallback")
 }
 
 @Test func testLocalizedDescriptionWithEmptyEnglish() {
@@ -85,30 +83,15 @@ import Foundation
     #expect(desc.localizedString == "")
 }
 
-@Test func testLocalizedDescriptionAllLanguagesProvided() {
+@Test func testLocalizedDescriptionNorwegianAliases() {
     let desc = LocalizedDescription(
-        en: "Hello",
-        de: "Hallo",
-        es: "Hola",
-        fr: "Bonjour",
-        it: "Ciao",
-        ja: "こんにちは",
-        ko: "안녕하세요",
-        ru: "Привет",
-        zhHans: "你好",
-        zhHant: "你好"
+        en: "English text",
+        no: "Norsk tekst"
     )
-    
-    // Should return a valid localized string
-    let localizedString = desc.localizedString
-    #expect(!localizedString.isEmpty)
-    
-    // Should be one of the provided translations
-    let allTranslations = [
-        desc.en, desc.de!, desc.es!, desc.fr!, desc.it!,
-        desc.ja!, desc.ko!, desc.ru!, desc.zhHans!, desc.zhHant!
-    ]
-    #expect(allTranslations.contains(localizedString))
+
+    #expect(desc.localizedString(for: Locale(identifier: "no")) == "Norsk tekst")
+    #expect(desc.localizedString(for: Locale(identifier: "nb")) == "Norsk tekst")
+    #expect(desc.localizedString(for: Locale(identifier: "nn")) == "Norsk tekst")
 }
 
 // MARK: - LocalizedDescription Codable Tests
@@ -332,20 +315,20 @@ import Foundation
 
 // MARK: - LocalizedDescription Locale-Specific Tests
 
-@Test func testLocalizedDescriptionLanguageFallbacks() {
+@Test func testLocalizedDescriptionChineseScriptAndRegionHandling() {
     let desc = LocalizedDescription(
         en: "English fallback",
-        de: "German text",
-        es: "Spanish text"
+        zhHans: "Simplified Chinese text",
+        zhHant: "Traditional Chinese text"
     )
-    
-    // Test that we always get a non-empty string
-    let localizedString = desc.localizedString
-    #expect(!localizedString.isEmpty)
-    
-    // Should be one of the provided translations
-    let availableTranslations = [desc.en, desc.de, desc.es].compactMap { $0 }
-    #expect(availableTranslations.contains(localizedString))
+
+    #expect(desc.localizedString(for: Locale(identifier: "zh-Hans")) == "Simplified Chinese text")
+    #expect(desc.localizedString(for: Locale(identifier: "zh_CN")) == "Simplified Chinese text")
+    #expect(desc.localizedString(for: Locale(identifier: "zh_SG")) == "Simplified Chinese text")
+    #expect(desc.localizedString(for: Locale(identifier: "zh")) == "Simplified Chinese text")
+    #expect(desc.localizedString(for: Locale(identifier: "zh-Hant")) == "Traditional Chinese text")
+    #expect(desc.localizedString(for: Locale(identifier: "zh_HK")) == "Traditional Chinese text")
+    #expect(desc.localizedString(for: Locale(identifier: "zh_TW")) == "Traditional Chinese text")
 }
 
 @Test func testLocalizedDescriptionWithNilValues() {


### PR DESCRIPTION
## Why
`LocalizedDescription.localizedString` previously depended directly on `Locale.current`, which made locale-specific behavior hard to verify in tests. That left German fallback, Norwegian aliases, and Chinese script/region branches effectively untested.

## What Changed
- Added `localizedString(for locale: Locale)` and made `localizedString` delegate to it.
- Replaced broad locale assertions with deterministic tests for German selection/fallback.
- Added explicit tests for `no`, `nb`, and `nn` alias handling.
- Added explicit tests for Simplified and Traditional Chinese via script and region identifiers.

## Validation
- `CLANG_MODULE_CACHE_PATH=/tmp/clang-module-cache swift test --disable-sandbox --filter AppAboutViewTests`

## Risk Assessment
Low risk. The public behavior of `localizedString` is preserved, and the new helper only exposes the existing selection logic for controlled testing.

## Agent Confidence
High. The change is narrow, keeps runtime behavior intact, and the targeted test suite passed after the update.